### PR TITLE
improve error handling from client, fix cluster deletion

### DIFF
--- a/kubermatic/provider.go
+++ b/kubermatic/provider.go
@@ -2,6 +2,7 @@ package kubermatic
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -203,4 +204,13 @@ func newAuth(token, tokenPath string) (runtime.ClientAuthInfoWriter, error) {
 	}
 
 	return oclient.BearerToken(token), nil
+}
+
+// getErrorResponse converts the client error response to string
+func getErrorResponse(err error) string {
+	rawData, newErr := json.Marshal(err)
+	if newErr != nil {
+		return err.Error()
+	}
+	return string(rawData)
 }

--- a/kubermatic/resource_node_deployment.go
+++ b/kubermatic/resource_node_deployment.go
@@ -79,7 +79,7 @@ func resourceNodeDeploymentCreate(d *schema.ResourceData, m interface{}) error {
 
 	r, err := k.client.Project.CreateNodeDeployment(p, k.auth)
 	if err != nil {
-		return fmt.Errorf("unable to create a node deployment: %v", err)
+		return fmt.Errorf("unable to create a node deployment: %s", getErrorResponse(err))
 	}
 	nID := r.Payload.ID
 
@@ -92,7 +92,7 @@ func resourceNodeDeploymentCreate(d *schema.ResourceData, m interface{}) error {
 
 		r, err := k.client.Project.GetNodeDeployment(p, k.auth)
 		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("unable to get node deployment '%s' status: %v", nID, err))
+			return resource.NonRetryableError(fmt.Errorf("unable to get node deployment '%s' status: %s", nID, getErrorResponse(err)))
 		}
 
 		if r.Payload.Status.ReadyReplicas < *r.Payload.Spec.Replicas {
@@ -130,7 +130,7 @@ func resourceNodeDeploymentRead(d *schema.ResourceData, m interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("unable to get node deployment '%s': %v", d.Id(), err)
+		return fmt.Errorf("unable to get node deployment '%s': %s", d.Id(), getErrorResponse(err))
 	}
 
 	err = d.Set("name", r.Payload.Name)
@@ -178,7 +178,7 @@ func resourceNodeDeploymentDelete(d *schema.ResourceData, m interface{}) error {
 	_, err := k.client.Project.DeleteNodeDeployment(p, k.auth)
 	if err != nil {
 		// TODO: check if not found
-		return fmt.Errorf("unable to delete node deployment '%s': %v", nID, err)
+		return fmt.Errorf("unable to delete node deployment '%s': %s", nID, getErrorResponse(err))
 	}
 
 	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
@@ -195,7 +195,7 @@ func resourceNodeDeploymentDelete(d *schema.ResourceData, m interface{}) error {
 				d.SetId("")
 				return nil
 			}
-			return resource.NonRetryableError(fmt.Errorf("unable to get node deployment '%s': %v", nID, err))
+			return resource.NonRetryableError(fmt.Errorf("unable to get node deployment '%s': %s", nID, getErrorResponse(err)))
 		}
 
 		k.log.Debugf("node deployment '%s' deletion in progress, deletionTimestamp: %s",

--- a/kubermatic/resource_project.go
+++ b/kubermatic/resource_project.go
@@ -71,7 +71,7 @@ func resourceProjectCreate(d *schema.ResourceData, m interface{}) error {
 
 	r, err := k.client.Project.CreateProject(p, k.auth)
 	if err != nil {
-		return fmt.Errorf("error when creating a project: %s", err)
+		return fmt.Errorf("error when creating a project: %s", getErrorResponse(err))
 	}
 	d.SetId(r.Payload.ID)
 
@@ -121,7 +121,7 @@ func resourceProjectRead(d *schema.ResourceData, m interface{}) error {
 
 		}
 
-		return fmt.Errorf("unable to get project '%s': %v", d.Id(), err)
+		return fmt.Errorf("unable to get project '%s': %s", d.Id(), getErrorResponse(err))
 	}
 
 	if err := d.Set("labels", r.Payload.Labels); err != nil {
@@ -155,7 +155,7 @@ func resourceProjectUpdate(d *schema.ResourceData, m interface{}) error {
 
 	_, err := k.client.Project.UpdateProject(p.WithProjectID(d.Id()), k.auth)
 	if err != nil {
-		return fmt.Errorf("unable to update project '%s': %v", d.Id(), err)
+		return fmt.Errorf("unable to update project '%s': %s", d.Id(), getErrorResponse(err))
 	}
 
 	return resourceProjectRead(d, m)
@@ -166,7 +166,7 @@ func resourceProjectDelete(d *schema.ResourceData, m interface{}) error {
 	p := project.NewDeleteProjectParams()
 	_, err := k.client.Project.DeleteProject(p.WithProjectID(d.Id()), k.auth)
 	if err != nil {
-		return fmt.Errorf("unable to delete project '%s': %s", d.Id(), err)
+		return fmt.Errorf("unable to delete project '%s': %s", d.Id(), getErrorResponse(err))
 	}
 
 	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {

--- a/kubermatic/resource_sshkey.go
+++ b/kubermatic/resource_sshkey.go
@@ -1,6 +1,7 @@
 package kubermatic
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -53,7 +54,7 @@ func resourceSSHKeyCreate(d *schema.ResourceData, m interface{}) error {
 	}
 	created, err := k.client.Project.CreateSSHKey(p, k.auth)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create SSH key: %s", getErrorResponse(err))
 	}
 	d.SetId(created.Payload.ID)
 	return resourceSSHKeyRead(d, m)
@@ -65,7 +66,7 @@ func resourceSSHKeyRead(d *schema.ResourceData, m interface{}) error {
 	p.SetProjectID(d.Get("project_id").(string))
 	ret, err := k.client.Project.ListSSHKeys(p, k.auth)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to list SSH keys: %s", getErrorResponse(err))
 	}
 	var sshkey *models.SSHKey
 	for _, r := range ret.Payload {
@@ -89,5 +90,5 @@ func resourceSSHKeyDelete(d *schema.ResourceData, m interface{}) error {
 	p.SetProjectID(d.Get("project_id").(string))
 	p.SetSSHKeyID(d.Id())
 	_, err := k.client.Project.DeleteSSHKey(p, k.auth)
-	return err
+	return fmt.Errorf("unable to delete SSH key: %s", getErrorResponse(err))
 }


### PR DESCRIPTION
The kubermatic client returns an error pointer to the JSON structure. The PR improves displaying errors from the client. The deleting cluster was in an infinite loop.